### PR TITLE
Fix `accessibility` prop’s `propType`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ NanoClamp.defaultProps = {
 }
 
 NanoClamp.propTypes = {
-  accessibility: PropTypes.boolean,
+  accessibility: PropTypes.bool,
   is: PropTypes.string,
   lines: PropTypes.number,
   debounce: PropTypes.number,


### PR DESCRIPTION
+ `boolean` -> `bool`

It was throwing a console warning:

```
Failed prop type: NanoClamp: prop type `accessibility` is invalid; it must be a function, usually from the `prop-types` package, but received `undefined`.
``` 