### PR TITLE
build: setup babel helpers as runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,8 @@
   "env": {
     "production": {
       "plugins": [
-        "@babel/plugin-transform-react-constant-elements"
+        "@babel/plugin-transform-react-constant-elements",
+        "@babel/plugin-transform-runtime"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -44,8 +44,10 @@
   "devDependencies": {
     "@babel/eslint-parser": "latest",
     "@babel/plugin-transform-react-constant-elements": "latest",
+    "@babel/plugin-transform-runtime": "latest",
     "@babel/preset-env": "latest",
     "@babel/preset-react": "latest",
+    "@babel/runtime": "latest",
     "@commitlint/cli": "latest",
     "@commitlint/config-conventional": "latest",
     "@rollup/plugin-babel": "latest",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,9 @@
 import external from 'rollup-plugin-peer-deps-external'
 import { visualizer } from 'rollup-plugin-visualizer'
-import terser from '@rollup/plugin-terser'
-import filesize from 'rollup-plugin-filesize'
-import babel from '@rollup/plugin-babel'
 import typescript from '@rollup/plugin-typescript'
+import filesize from 'rollup-plugin-filesize'
+import terser from '@rollup/plugin-terser'
+import babel from '@rollup/plugin-babel'
 import fs from 'fs'
 
 import pkg from './package.json'
@@ -12,6 +12,7 @@ const babelRc = JSON.parse(fs.readFileSync('./.babelrc'))
 
 export default {
   input: 'src/index.ts',
+  external: [/@babel\/runtime/],
   output: [
     {
       file: pkg.main,
@@ -30,7 +31,7 @@ export default {
     }),
     babel({
       babelrc: false,
-      babelHelpers: 'inline',
+      babelHelpers: 'runtime',
       ...babelRc
     }),
     typescript(),


### PR DESCRIPTION
According to [rollup babel plugin](https://github.com/rollup/plugins/tree/master/packages/babel#babelhelpers):

> 'runtime' - you should use this especially when building libraries with Rollup. 