### PR TITLE
refactor: use mjs extension for module bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/microlinkhq/nanoclamp",
   "version": "2.0.0",
   "main": "dist/nanoclamp.js",
-  "module": "dist/nanoclamp.m.js",
+  "module": "dist/nanoclamp.mjs",
   "author": {
     "name": "Brad Adams"
   },


### PR DESCRIPTION
It's the official way without extra configuration:

> Authors can tell Node.js to use the ECMAScript modules loader via the .mjs file extension, the package.json "type" field, or the --input-type flag.

Related: https://nodejs.org/api/esm.html